### PR TITLE
Support for notifications and listening for changes

### DIFF
--- a/btlewrap/base.py
+++ b/btlewrap/base.py
@@ -70,6 +70,8 @@ class AbstractBackend(object):
     This class will be overridden by the different backends used by miflora.
     """
 
+    _DATA_MODE_LISTEN = bytes([0x01, 0x00])
+
     def __init__(self, adapter):
         self.adapter = adapter
 
@@ -89,6 +91,12 @@ class AbstractBackend(object):
         """Write a value to a handle.
 
         You must be connected to a device first."""
+        raise NotImplementedError
+
+    def wait_for_notification(self, handle, delegate, timeout):
+        """ registers as a listener and calls the delegate's handleNotification
+            for each notification received
+        """
         raise NotImplementedError
 
     def read_handle(self, handle):

--- a/btlewrap/base.py
+++ b/btlewrap/base.py
@@ -1,4 +1,4 @@
-"""Bluetooth Backends available for miflora."""
+"""Bluetooth Backends available for miflora and other btle sensors."""
 from threading import Lock
 
 
@@ -67,7 +67,7 @@ class BluetoothBackendException(Exception):
 class AbstractBackend(object):
     """Abstract base class for talking to Bluetooth LE devices.
 
-    This class will be overridden by the different backends used by miflora.
+    This class will be overridden by the different backends used by miflora and other btle sensors.
     """
 
     _DATA_MODE_LISTEN = bytes([0x01, 0x00])
@@ -93,9 +93,13 @@ class AbstractBackend(object):
         You must be connected to a device first."""
         raise NotImplementedError
 
-    def wait_for_notification(self, handle, delegate, timeout):
+    def wait_for_notification(self, handle, delegate, notification_timeout):
         """ registers as a listener and calls the delegate's handleNotification
             for each notification received
+            @param handle - the handle to use to register for notifications
+            @param: delegate - the delegate object's handleNotification is called for every notification received
+            @param: notification_timeout - wait this amount of seconds for notifications
+
         """
         raise NotImplementedError
 

--- a/btlewrap/bluepy.py
+++ b/btlewrap/bluepy.py
@@ -80,6 +80,14 @@ class BluepyBackend(AbstractBackend):
             raise BluetoothBackendException('not connected to backend')
         return self._peripheral.writeCharacteristic(handle, value, True)
 
+    @wrap_exception
+    def wait_for_notification(self, handle, delegate, timeout):
+        if self._peripheral is None:
+            raise BluetoothBackendException('not connected to backend')
+        self.write_handle(handle, self._DATA_MODE_LISTEN)
+        self._peripheral.withDelegate(delegate)
+        return self._peripheral.waitForNotifications(timeout)
+
     @staticmethod
     def check_backend():
         """Check if the backend is available."""

--- a/btlewrap/bluepy.py
+++ b/btlewrap/bluepy.py
@@ -81,12 +81,12 @@ class BluepyBackend(AbstractBackend):
         return self._peripheral.writeCharacteristic(handle, value, True)
 
     @wrap_exception
-    def wait_for_notification(self, handle, delegate, timeout):
+    def wait_for_notification(self, handle, delegate, notification_timeout):
         if self._peripheral is None:
             raise BluetoothBackendException('not connected to backend')
         self.write_handle(handle, self._DATA_MODE_LISTEN)
         self._peripheral.withDelegate(delegate)
-        return self._peripheral.waitForNotifications(timeout)
+        return self._peripheral.waitForNotifications(notification_timeout)
 
     @staticmethod
     def check_backend():

--- a/btlewrap/gatttool.py
+++ b/btlewrap/gatttool.py
@@ -192,7 +192,9 @@ class GatttoolBackend(AbstractBackend):
         """
         data = []
         for element in process_output.splitlines()[1:]:
-            data.append(element.split(": ")[1])
+            parts = element.split(": ")
+            if len(parts) == 2:
+                data.append(parts[1])
         return data
 
     @wrap_exception

--- a/test/helper.py
+++ b/test/helper.py
@@ -32,3 +32,7 @@ class MockBackend(AbstractBackend):
         """Writing handles just stores the results in a list."""
         self.written_handles.append((handle, value))
         return handle in self.expected_write_handles
+
+    def wait_for_notification(self, handle, delegate, timeout):
+        """same as write_handle. Delegate is not used, yet."""
+        return self.write_handle(handle, self._DATA_MODE_LISTEN)

--- a/test/helper.py
+++ b/test/helper.py
@@ -33,6 +33,7 @@ class MockBackend(AbstractBackend):
         self.written_handles.append((handle, value))
         return handle in self.expected_write_handles
 
-    def wait_for_notification(self, handle, delegate, timeout):
+    def wait_for_notification(self, handle, delegate, notification_timeout):
         """same as write_handle. Delegate is not used, yet."""
+        delegate.handleNotification(bytes([int(x, 16) for x in "54 3d 32 37 2e 33 20 48 3d 32 37 2e 30 00".split()]))
         return self.write_handle(handle, self._DATA_MODE_LISTEN)

--- a/test/unit_tests/test_bluepy.py
+++ b/test/unit_tests/test_bluepy.py
@@ -44,3 +44,11 @@ class TestBluepy(unittest.TestCase):
         backend = BluepyBackend()
         with self.assertRaises(BluetoothBackendException):
             backend.connect(TEST_MAC)
+
+    @mock.patch('bluepy.btle.Peripheral')
+    def test_wait_for_notification(self, mock_peripheral):
+        """Test writing to a handle successfully."""
+        backend = BluepyBackend()
+        backend.connect(TEST_MAC)
+        self.assertTrue(backend.wait_for_notification(0xFF, None, 10))
+        mock_peripheral.assert_called_with(TEST_MAC, iface=0)

--- a/test/unit_tests/test_gatttool.py
+++ b/test/unit_tests/test_gatttool.py
@@ -64,6 +64,17 @@ class TestGatttool(unittest.TestCase):
         with self.assertRaises(BluetoothBackendException):
             backend.read_handle(0xFF)
 
+    @mock.patch('os.killpg')
+    @mock.patch('btlewrap.gatttool.Popen')
+    @mock.patch('time.sleep', return_value=None)
+    def test_read_handle_timeout(self, time_mock, popen_mock, os_mock):
+        """Test notification when timeout"""
+        _configure_popenmock_timeout(popen_mock, "Characteristic")
+        backend = GatttoolBackend()
+        backend.connect(TEST_MAC)
+        with self.assertRaises(BluetoothBackendException):
+            backend.read_handle(0xFF)
+
     def test_write_not_connected(self):
         """Test writing data when not connected."""
         backend = GatttoolBackend()
@@ -94,6 +105,17 @@ class TestGatttool(unittest.TestCase):
     def test_write_handle_no_answer(self, time_mock, popen_mock):
         """Test writing to a handle when no result is returned."""
         _configure_popenmock(popen_mock, '')
+        backend = GatttoolBackend()
+        backend.connect(TEST_MAC)
+        with self.assertRaises(BluetoothBackendException):
+            backend.write_handle(0xFF, b'\x00\x10\xFF')
+
+    @mock.patch('os.killpg')
+    @mock.patch('btlewrap.gatttool.Popen')
+    @mock.patch('time.sleep', return_value=None)
+    def test_write_handle_timeout(self, time_mock, popen_mock, os_mock):
+        """Test notification when timeout"""
+        _configure_popenmock_timeout(popen_mock, "Characteristic")
         backend = GatttoolBackend()
         backend.connect(TEST_MAC)
         with self.assertRaises(BluetoothBackendException):

--- a/test/unit_tests/test_gatttool.py
+++ b/test/unit_tests/test_gatttool.py
@@ -78,6 +78,15 @@ class TestGatttool(unittest.TestCase):
 
     @mock.patch('btlewrap.gatttool.Popen')
     @mock.patch('time.sleep', return_value=None)
+    def test_wait_for_notification(self, time_mock, popen_mock):
+        """Test writing to a handle successfully."""
+        _configure_popenmock(popen_mock, 'Characteristic value was written successfully')
+        backend = GatttoolBackend()
+        backend.connect(TEST_MAC)
+        self.assertTrue(backend.wait_for_notification(0xFF, None, 10))
+
+    @mock.patch('btlewrap.gatttool.Popen')
+    @mock.patch('time.sleep', return_value=None)
     def test_write_handle_wrong_handle(self, time_mock, popen_mock):
         """Test writing to a non-writable handle."""
         _configure_popenmock(popen_mock, "Characteristic Write Request failed: Attribute can't be written")


### PR DESCRIPTION
Small improvements to the BE implementations (notably to bluepy and gatttool) so that clients are able to register for notifications and listen for changes