### PR TITLE
Add address_type argument for backends

### DIFF
--- a/btlewrap/base.py
+++ b/btlewrap/base.py
@@ -8,8 +8,8 @@ class BluetoothInterface(object):
     This class takes care of locking and the context managers.
     """
 
-    def __init__(self, backend, adapter='hci0', **kwargs):
-        self._backend = backend(adapter, **kwargs)
+    def __init__(self, backend, adapter='hci0', address_type='public', **kwargs):
+        self._backend = backend(adapter, address_type=address_type, **kwargs)
         self._backend.check_backend()
 
     def __del__(self):

--- a/btlewrap/bluepy.py
+++ b/btlewrap/bluepy.py
@@ -37,9 +37,10 @@ def wrap_exception(func):
 class BluepyBackend(AbstractBackend):
     """Backend for Miflora using the bluepy library."""
 
-    def __init__(self, adapter='hci0'):
+    def __init__(self, adapter='hci0', address_type='public'):
         """Create new instance of the backend."""
         super(BluepyBackend, self).__init__(adapter)
+        self.address_type = address_type
         self._peripheral = None
 
     @wrap_exception
@@ -52,7 +53,7 @@ class BluepyBackend(AbstractBackend):
                 'Invalid pattern "{}" for BLuetooth adpater. '
                 'Expetected something like "hci0".'.format(self.adapter))
         iface = int(match_result.group(1))
-        self._peripheral = Peripheral(mac, iface=iface)
+        self._peripheral = Peripheral(mac, iface=iface, addrType=self.address_type)
 
     @wrap_exception
     def disconnect(self):

--- a/btlewrap/gatttool.py
+++ b/btlewrap/gatttool.py
@@ -29,11 +29,12 @@ def wrap_exception(func):
 class GatttoolBackend(AbstractBackend):
     """ Backend using gatttool."""
 
-    def __init__(self, adapter='hci0', retries=3, timeout=20):
+    def __init__(self, adapter='hci0', retries=3, timeout=20, address_type='public'):
         super(GatttoolBackend, self).__init__(adapter)
         self.adapter = adapter
         self.retries = retries
         self.timeout = timeout
+        self.address_type = address_type
         self._mac = None
 
     def connect(self, mac):
@@ -74,9 +75,8 @@ class GatttoolBackend(AbstractBackend):
         _LOGGER.debug("Enter write_ble (%s)", current_thread())
 
         while attempt <= self.retries:
-            cmd = "gatttool --device={} --char-write-req -a {} -n {} --adapter={}".format(
-                self._mac, self.byte_to_handle(handle), self.bytes_to_string(value), self.adapter)
-
+            cmd = "gatttool --device={} --addr-type={} --char-write-req -a {} -n {} --adapter={}".format(
+                self._mac, self.address_type, self.byte_to_handle(handle), self.bytes_to_string(value), self.adapter)
             _LOGGER.debug("Running gatttool with a timeout of %d: %s",
                           self.timeout, cmd)
 
@@ -133,8 +133,8 @@ class GatttoolBackend(AbstractBackend):
         _LOGGER.debug("Enter write_ble (%s)", current_thread())
 
         while attempt <= self.retries:
-            cmd = "gatttool --device={} --char-write-req -a {} -n {} --adapter={} --listen".format(
-                self._mac, self.byte_to_handle(handle), self.bytes_to_string(self._DATA_MODE_LISTEN), self.adapter)
+            cmd = "gatttool --device={} --addr-type={} --char-write-req -a {} -n {} --adapter={} --listen".format(
+                self._mac, self.address_type, self.byte_to_handle(handle), self.bytes_to_string(self._DATA_MODE_LISTEN), self.adapter)
             _LOGGER.debug("Running gatttool with a timeout of %d: %s", notification_timeout, cmd)
 
             with Popen(cmd,
@@ -214,8 +214,8 @@ class GatttoolBackend(AbstractBackend):
         _LOGGER.debug("Enter read_ble (%s)", current_thread())
 
         while attempt <= self.retries:
-            cmd = "gatttool --device={} --char-read -a {} --adapter={}".format(
-                self._mac, self.byte_to_handle(handle), self.adapter)
+            cmd = "gatttool --device={} --addr-type={} --char-read -a {} --adapter={}".format(
+                self._mac, self.address_type, self.byte_to_handle(handle), self.adapter)
             _LOGGER.debug("Running gatttool with a timeout of %d: %s",
                           self.timeout, cmd)
             with Popen(cmd,

--- a/btlewrap/pygatt.py
+++ b/btlewrap/pygatt.py
@@ -30,7 +30,7 @@ class PygattBackend(AbstractBackend):
     """Bluetooth backend for Blue Giga based bluetooth devices."""
 
     @wrap_exception
-    def __init__(self, adapter=None):
+    def __init__(self, adapter=None, address_type='public'):
         """Create a new instance.
 
         Note: the parameter "adapter" is ignored, pygatt detects the right USB port automagically.
@@ -42,6 +42,7 @@ class PygattBackend(AbstractBackend):
         self._adapter = pygatt.BGAPIBackend()
         self._adapter.start()
         self._device = None
+        self._address_type = address_type
 
     def __del__(self):
         if self._adapter is not None:
@@ -50,7 +51,10 @@ class PygattBackend(AbstractBackend):
     @wrap_exception
     def connect(self, mac):
         """Connect to a device."""
-        self._device = self._adapter.connect(mac)
+        address_type = pygatt.BLEAddressType.public
+        if self._address_type == 'random':
+            address_type = pygatt.BLEAddressType.random
+        self._device = self._adapter.connect(mac, address_type=address_type)
 
     def is_connected(self):
         """Check if connected to a device."""


### PR DESCRIPTION
Thanks for this wrapper.
I wanted to use it with a completely different device, one that needs the 'random' address type instead of 'public'.

I've added an aditional argument to the bluetooth interface to allow this. The default is still 'public' so
```BluetoothInterface(backend, adapter)``` is equal to ```BluetoothInterface(backend, adapter, address_type='public')``` meaning scripts implementing btewrap in the 'old' way should still work the same, but it also allows you run run ```BluetoothInterface(backend, adapter, address_type='random')``` to use the random address type.

I've implemented this in all three backends but was only able to test it for bluepy and gatttool as pygatt doesn't seem to work on my system. I think it should work, maybe you can take a look and confirm this?