### PR TITLE
Append parameter adapter for scan_for_devices

### DIFF
--- a/btlewrap/base.py
+++ b/btlewrap/base.py
@@ -125,7 +125,7 @@ class AbstractBackend(object):
         raise NotImplementedError
 
     @staticmethod
-    def scan_for_devices(timeout):
+    def scan_for_devices(timeout, adapter):
         """Scan for additional devices.
 
         Returns a list of all the mac addresses of Xiaomi Mi Flower sensor that could be found.

--- a/btlewrap/bluepy.py
+++ b/btlewrap/bluepy.py
@@ -103,13 +103,20 @@ class BluepyBackend(AbstractBackend):
 
     @staticmethod
     @wrap_exception
-    def scan_for_devices(timeout):
+    def scan_for_devices(timeout, adapter='hci0'):
         """Scan for bluetooth low energy devices.
 
         Note this must be run as root!"""
         from bluepy.btle import Scanner
 
-        scanner = Scanner()
+        match_result = re.search(r'hci([\d]+)', adapter)
+        if match_result is None:
+            raise BluetoothBackendException(
+                'Invalid pattern "{}" for BLuetooth adpater. '
+                'Expetected something like "hci0".'.format(adapter))
+        iface = int(match_result.group(1))
+
+        scanner = Scanner(iface=iface)
         result = []
         for device in scanner.scan(timeout):
             result.append((device.addr, device.getValueText(9)))


### PR DESCRIPTION
I am planning a system where more than one adapter will be used, and unfortunately your scanner does not support other devices besides the default device.