### PR TITLE
Release lock unconditionally if connect() fails

### DIFF
--- a/btlewrap/base.py
+++ b/btlewrap/base.py
@@ -43,7 +43,7 @@ class _BackendConnection(object):  # pylint: disable=too-few-public-methods
         try:
             self._backend.connect(self._mac)
         # release lock on any exceptions otherwise it will never be unlocked
-        except:  # noqa: E722 
+        except:  # noqa: E722
             self._lock.release()
             raise
         return self._backend

--- a/btlewrap/base.py
+++ b/btlewrap/base.py
@@ -42,7 +42,8 @@ class _BackendConnection(object):  # pylint: disable=too-few-public-methods
         self._lock.acquire()
         try:
             self._backend.connect(self._mac)
-        except:
+        # release lock on any exceptions otherwise it will never be unlocked
+        except:  # noqa: E722 
             self._lock.release()
             raise
         return self._backend

--- a/btlewrap/base.py
+++ b/btlewrap/base.py
@@ -42,7 +42,7 @@ class _BackendConnection(object):  # pylint: disable=too-few-public-methods
         self._lock.acquire()
         try:
             self._backend.connect(self._mac)
-        except BluetoothBackendException:
+        except:
             self._lock.release()
             raise
         return self._backend


### PR DESCRIPTION
Hi,

when a [connect()](https://github.com/ChristianKuehnel/btlewrap/blob/18ade34a1768db121eb111f7040d4dc1076448af/btlewrap/base.py#L19) operation to a Bluetooth device is interrupted by any other exception than the internal [BluetoothBackendException](https://github.com/ChristianKuehnel/btlewrap/blob/18ade34a1768db121eb111f7040d4dc1076448af/btlewrap/base.py#L67), a previously acquired lock [is not released](https://github.com/ChristianKuehnel/btlewrap/blob/0dd97d98660a0641e42d377b113cb755e532aa4f/btlewrap/base.py#L42-L46). This occurs for instance when using a timeout mechanism like [interruptingcow](https://pypi.org/project/interruptingcow/) or [tenacity](https://pypi.org/project/tenacity/), where a RuntimeException is generated. When this happens, consequent connect() operations deadlock when trying to [acquiring](https://github.com/ChristianKuehnel/btlewrap/blob/18ade34a1768db121eb111f7040d4dc1076448af/btlewrap/base.py#L42) the already acquired lock.

I propose to release the lock unconditionally on exceptions, regardless of the exception type.

Note: The [\_\_exit\_\_](https://github.com/ChristianKuehnel/btlewrap/blob/18ade34a1768db121eb111f7040d4dc1076448af/btlewrap/base.py#L50) method is not being called, because the [\_\_enter\_\_](https://github.com/ChristianKuehnel/btlewrap/blob/18ade34a1768db121eb111f7040d4dc1076448af/btlewrap/base.py#L41) did not succeed. [\_\_del\_\_](https://github.com/ChristianKuehnel/btlewrap/blob/18ade34a1768db121eb111f7040d4dc1076448af/btlewrap/base.py#L53) has no effect, because the backend was not yet connected.

See also zewelor/bt-mqtt-gateway#39.