### PR TITLE
Fix BorkenPipeError by updating Bluepy to 1.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: python
 matrix:
   fast_finish: true
   include:
-  - python: 3.4.2
-    env: TOXENV=py34
   - python: '3.5'
     env: TOXENV=py35
   - python: '3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-bluepy==1.1.4
+bluepy==1.3.0
 pygatt==3.2.0
 typing>=3,<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-bluepy==1.3.0
+bluepy==1.2.0
 pygatt==3.2.0
 typing>=3,<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-bluepy==1.2.0
+bluepy==1.3.0
 pygatt==3.2.0
 typing>=3,<4

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34, py35, py36, py37, pylint, flake8, noimport
+envlist = py35, py36, py37, pylint, flake8, noimport
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
By updating `bluepy` from `1.1.4` to `1.2.0` this PR aims to fix the BrokenPipeError detailed in this ticket:
https://github.com/ChristianKuehnel/btlewrap/issues/14