### PR TITLE
upgraded to pylint 2.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: python
 matrix:
   fast_finish: true
   include:
-  - python: '3.4'
-    env: TOXENV=py34
   - python: '3.5'
     env: TOXENV=py35
   - python: '3.6'

--- a/pylintrc
+++ b/pylintrc
@@ -1,5 +1,5 @@
 [MESSAGES CONTROL]
-disable = abstract-method, too-many-instance-attributes, too-many-arguments, bad-whitespace
+disable = abstract-method, too-many-instance-attributes, too-many-arguments, bad-whitespace, import-outside-toplevel
 
 [FORMAT]
 max-line-length=120

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 pytest
 pytest-cov
 pytest-timeout
-pylint==2.2.2
+pylint==2.4.2
 flake8
 pexpect


### PR DESCRIPTION
removes some of the warnings in the log