### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Ensure that the tarball published on PyPI contains the LICNESE file.

Shipping the license file is a requirement for the Fedora package (and other distributions) thus it should be part of the upstream source.