### PR TITLE
Fix pygatt==3.2.0 because 3.4.0 doesn't exists

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(
     extras_require={
         'testing': ['pytest'], 
         'bluepy': ['bluepy==1.3.0'],
-        'pygatt': ['pygatt==3.4.0'], 
+        'pygatt': ['pygatt==3.2.0'], 
         },
 )


### PR DESCRIPTION
See https://github.com/basnijholt/miflora/runs/1086112337
Also requirements.txt has 3.2.0.