### PR TITLE
added blame ignore file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# re-formatted the code base with black
+a57981752513b21b43ce7d6b764ccff0d0d5a7e7


### PR DESCRIPTION
added a `.git-blame-ignore-revs` so that git blame keeps working after re-formatting the code base.